### PR TITLE
Collection semantics, untagged union

### DIFF
--- a/jadn-v1.1.md
+++ b/jadn-v1.1.md
@@ -879,19 +879,24 @@ as described in [Section 3.3.2](#332-field-multiplicity).
 Within a Choice type *minc* values of 0 and 1 are equivalent because all fields are optional and exactly
 one must be present. Values greater than 1 specify an array of elements.
 
-#### 3.2.2.2 Tagged and Untagged Unions
+#### 3.2.2.2 Union Types
+The Enumerated type matches one value (an Item ID or Name) from the set of ID/Name pairs defined by the type.
+
 The Choice type selects one type or a logical combination of types from a set. By default Choice is
 a discriminated ([tagged](#taggedunion)) union where data instances contain a tag (FieldName or FieldId)
-indicating which FieldType from the Choice to evaluate.
+indicating which FieldType from the Choice to evaluate. If a Choice has a [combine](#32112-combine)
+type option it is an [untagged](#union) union where values that match a logical combination of types
+are instances of the Choice type.
 
-If a Choice type has a [combine](#32112-combine) type option, data instances match a logical combination
-of types (`anyOf` (OR), `allOf` (AND), or exactly `oneOf` (XOR)) the field types in the Choice.
-The combine option specifies an untagged [union](#union): data instances do not contain a tag indicating which types
-apply; instead the Choice's FieldTypes are evaluated to determine which, if any, validate the data.
-The `anyOf` option performs short-circuit evaluation; the first FieldType to match, in field order, indicates the
-instance type. The `allOf` and `oneOf` options always perform the evaluation against all FieldTypes.
+##### 3.2.2.2.1 Enumerated
 
-##### 3.2.2.2.1 Tagged Union
+##### 3.2.2.2.2 Choice - Untagged Union
+The `combine` option specifies the logical function (`anyOf` (OR), `allOf` (AND), or exactly `oneOf` (XOR))
+of the Choice's field types apply to the value. The `anyOf` option performs short-circuit evaluation where
+the first FieldType to match, in field order, indicates the instance type.
+The `allOf` and `oneOf` options always perform the evaluation against all FieldTypes.
+
+##### 3.2.2.2.3 Choice - Tagged Union
 The Choice type without a combine option represents a [discriminated union](#union), a Map with exactly
 one tag:type pair where the tag indicates the value type. By default the tag is included in the instance
 value. But if the *tagid* option is present on a Choice field in an Array or Record container,

--- a/jadn-v1.1.md
+++ b/jadn-v1.1.md
@@ -506,15 +506,16 @@ The notation `X+y` indicates that the definition of type `X` includes type optio
 
 ###### Table 3-2. Mapping Logical Collections to Compound Types
 
-| Ordered | Unique | Collection<br>Semantics | Type<br>Syntax    | Field<br>Syntax                    |
-|---------|--------|-------------------------|-------------------|------------------------------------|
-| false   | true   | Set                     | ArrayOf+set       | Map<br>MapOf<br>Record             |
-| true    | false  | Sequence                | ArrayOf           | Array                              |
-| true    | true   | OrderedSet              | ArrayOf+unique    | Map+seq<br>MapOf+seq<br>Record+seq |
-| false   | false  | Bag                     | ArrayOf+unordered | none                               |
+| Ordered | Unique | Collection<br>Semantics | Type<br>Syntax    | Field<br>Syntax                             |
+|---------|--------|-------------------------|-------------------|---------------------------------------------|
+| false   | true   | Set                     | ArrayOf+set       | Map<br>MapOf<br>Record<br>Array+set         |
+| true    | false  | Sequence                | ArrayOf           | Map+seq<br>MapOf+seq<br>Record+seq<br>Array |
+| true    | true   | OrderedSet              | ArrayOf+unique    | none                                        |
+| false   | false  | Bag                     | ArrayOf+unordered | none                                        |
 
 Members of an ArrayOf or Array type are selected by ordinal position.
 Members of a Record type are selected by either position or name depending on data format.
+If a use case for OrderedSet Field Syntax is identified, a new compound type option can be defined to support it. 
 The members of a Bag collection cannot be selected; accessing a Bag instance returns an arbitrary member.
 
 **Union Types**:

--- a/jadn-v1.1.md
+++ b/jadn-v1.1.md
@@ -508,15 +508,16 @@ The notation `X+y` indicates that the definition of type `X` includes type optio
 
 | Ordered | Unique | Collection<br>Semantics | Type<br>Syntax    | Field<br>Syntax                             |
 |---------|--------|-------------------------|-------------------|---------------------------------------------|
-| false   | true   | Set                     | ArrayOf+set       | Map<br>MapOf<br>Record<br>Array+set         |
-| true    | false  | Sequence                | ArrayOf           | Map+seq<br>MapOf+seq<br>Record+seq<br>Array |
-| true    | true   | OrderedSet              | ArrayOf+unique    | none                                        |
+| false   | true   | Set                     | ArrayOf+set       | Array+set<br>Map<br>MapOf<br>Record         |
+| true    | false  | Sequence                | ArrayOf           | none                                        |
+| true    | true   | OrderedSet              | ArrayOf+unique    | Array<br>Map+seq<br>MapOf+seq<br>Record+seq |
 | false   | false  | Bag                     | ArrayOf+unordered | none                                        |
 
-Members of an ArrayOf or Array type are selected by ordinal position.
-Members of a Record type are selected by either position or name depending on data format.
-If a use case for OrderedSet Field Syntax is identified, a new compound type option can be defined to support it. 
-The members of a Bag collection cannot be selected; accessing a Bag instance returns an arbitrary member.
+* Members of an ArrayOf or Array type are selected by ordinal position.
+* Members of a Record type are selected by either position or name depending on data format.
+* Field positions are unique and by default Array has OrderedSet, not Sequence (non-unique) semantics.
+* Map, MapOf and Record keys are unique and with `seq` option have OrderedSet, not Sequence semantics.
+* The members of a Bag collection cannot be selected; accessing a Bag instance returns an arbitrary member.
 
 **Union Types**:
 

--- a/jadn-v1.1.md
+++ b/jadn-v1.1.md
@@ -450,7 +450,11 @@ allowing developers to use either approach.
 
 # 3 JADN Types
 An information modeling language's types are defined in terms of the characteristics they provide to applications.
-JADN's base types are:
+JADN defines a small set of built-in abstract data types in the following categories:
+
+* **Primitive**: atomic data types from which all other data types are constructed
+* **Compound**: patterns for constructing composite types from a collection of types 
+* **Union**: patterns for validating an instance against a set of possible values or types
 
 ###### Table 3-1. JADN Base Types
 
@@ -462,24 +466,19 @@ JADN's base types are:
 | Integer                 | A positive or negative whole number.                                                                                                                                                                                   |
 | Number                  | A real number.                                                                                                                                                                                                         |
 | String                  | A sequence of characters, each of which has a Unicode codepoint.  Length is the number of characters.                                                                                                                  |
-| **Union**               |                                                                                                                                                                                                                        |
-| Enumerated              | A vocabulary: one item (id/string pair) selected from a set of items.                                                                                                                                                  |
-| Choice                  | A tagged (discriminated) or untagged union: a type or logical combination of types.                                                                                                                                    |
 | **Compound**            |                                                                                                                                                                                                                        |
 | Array                   | An ordered list of labeled fields with positionally-defined semantics. Each field has a position, label, and type.                                                                                                     |
 | ArrayOf(*vtype*)        | A collection of fields with the same semantics. Each field has type *vtype*. Ordering and uniqueness are specified by a collection option.                                                                             |
 | Map                     | An unordered map from a set of specified keys to values with semantics bound to each key. Each key has an id and name or label, and is mapped to a value type.                                                         |
 | MapOf(*ktype*, *vtype*) | An unordered map from a set of keys of the same type to values with the same semantics. Each key has key type *ktype*, and is mapped to value type *vtype*.                                                            |
 | Record                  | An ordered map from a list of keys with positions to values with positionally-defined semantics. Each key has a position and name, and is mapped to a value type. Represents a row in a spreadsheet or database table. |
+| **Union**               |                                                                                                                                                                                                                        |
+| Enumerated              | A vocabulary, a set of item (id/string pair) values. An instance must be a member of the set.                                                                                                                          |
+| Choice                  | A tagged or untagged union, a set of types or a logical combination of types. An instance must match the type designated by the tag or match the specified logical combination.                                        |
 
-* An application that uses JADN types MUST exhibit the behavior specified in Table 3-1.
-Applications MAY use any programming language data types or mechanisms that exhibit the required behavior.
-* An instance of a Map, MapOf, or Record type MUST NOT have more than one occurrence of each key.
-* An instance of a Map, MapOf, or Record type MUST NOT have a key of the null type.
-* An instance of a Map, MapOf, or Record type with a key mapped to a null value MUST compare as equal to an
-otherwise identical instance without that key.
-* The length of an Array, ArrayOf or Record instance MUST not include null values after the last non-null value.
-* Two Array, ArrayOf or Record instances that differ only in the number of trailing nulls MUST compare as equal.
+**Primitive Types**:
+
+**Compound Types**:
 
 JADN Compound types define logical collections and express both semantic characteristics and abstract syntax.
 
@@ -512,7 +511,21 @@ The notation X+y indicates that the definition of type X includes type option y 
 Elements of Sequence and OrderedSet collections are selected by position.
 The elements of a Bag collection cannot be selected; accessing returns an arbitrary member.
 
+**Union Types**:
+
+**Conformance**:
+
+* An application that uses JADN types MUST exhibit the behavior specified in Table 3-1.
+Applications MAY use any programming language data types or mechanisms that exhibit the required behavior.
+* An instance of a Map, MapOf, or Record type MUST NOT have more than one occurrence of each key.
+* An instance of a Map, MapOf, or Record type MUST NOT have a key of the null type.
+* An instance of a Map, MapOf, or Record type with a key mapped to a null value MUST compare as equal to an
+otherwise identical instance without that key.
+* The length of an Array, ArrayOf or Record instance MUST not include null values after the last non-null value.
+* Two Array, ArrayOf or Record instances that differ only in the number of trailing nulls MUST compare as equal.
+
 ## 3.1 Type Definitions
+
 JADN type definitions have a fixed structure designed to be easily describable, easily processed, stable, and extensible.
 
 * Every definition has five elements:

--- a/jadn-v1.1.md
+++ b/jadn-v1.1.md
@@ -458,45 +458,50 @@ JADN defines a small set of built-in abstract data types in the following catego
 
 ###### Table 3-1. JADN Base Types
 
-| Type                    | Definition                                                                                                                                                                                                             |
-|:------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Primitive**           |                                                                                                                                                                                                                        |
-| Binary                  | A sequence of octets.  Length is the number of octets.                                                                                                                                                                 |
-| Boolean                 | An element with one of two values: true or false.                                                                                                                                                                      |
-| Integer                 | A positive or negative whole number.                                                                                                                                                                                   |
-| Number                  | A real number.                                                                                                                                                                                                         |
-| String                  | A sequence of characters, each of which has a Unicode codepoint.  Length is the number of characters.                                                                                                                  |
-| **Compound**            |                                                                                                                                                                                                                        |
-| Array                   | An ordered list of labeled fields with positionally-defined semantics. Each field has a position, label, and type.                                                                                                     |
-| ArrayOf(*vtype*)        | A collection of fields with the same semantics. Each field has type *vtype*. Ordering and uniqueness are specified by a collection option.                                                                             |
-| Map                     | An unordered map from a set of specified keys to values with semantics bound to each key. Each key has an id and name or label, and is mapped to a value type.                                                         |
-| MapOf(*ktype*, *vtype*) | An unordered map from a set of keys of the same type to values with the same semantics. Each key has key type *ktype*, and is mapped to value type *vtype*.                                                            |
-| Record                  | An ordered map from a list of keys with positions to values with positionally-defined semantics. Each key has a position and name, and is mapped to a value type. Represents a row in a spreadsheet or database table. |
-| **Union**               |                                                                                                                                                                                                                        |
-| Enumerated              | A vocabulary, a set of item (id/string pair) values. An instance must be a member of the set.                                                                                                                          |
-| Choice                  | A tagged or untagged union, a set of types or a logical combination of types. An instance must match the type designated by the tag or match the specified logical combination.                                        |
+| Type                    | Definition                                                                                                                                                                     |
+|:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Primitive**           |                                                                                                                                                                                |
+| Binary                  | A sequence of octets.  Length is the number of octets.                                                                                                                         |
+| Boolean                 | An element with one of two values: true or false.                                                                                                                              |
+| Integer                 | A positive or negative whole number.                                                                                                                                           |
+| Number                  | A real number.                                                                                                                                                                 |
+| String                  | A sequence of characters, each of which has a Unicode codepoint.  Length is the number of characters.                                                                          |
+| **Compound**            |                                                                                                                                                                                |
+| Array                   | An ordered list of labeled fields with positionally-defined types. Each field has a position, label, and type.                                                                 |
+| ArrayOf(*vtype*)        | A collection of fields with the same type *vtype*. Ordering and uniqueness are specified by a collection option.                                                               |
+| Map                     | A map from a set of specified keys to values with a value type bound to each key. Each key has an id and a name or label.                                                      |
+| MapOf(*ktype*, *vtype*) | A map from a set of keys of the same type *ktype* to values with the same type *vtype*.                                                                                        |
+| Record                  | A map from a list of keys to values with a value type bound to each key. Each key has a position and a name.                                                                   |
+| **Union**               |                                                                                                                                                                                |
+| Enumerated              | A vocabulary, a set of item (id/string pair) values. An instance is a single member of the set.                                                                                |
+| Choice                  | A tagged or untagged union, a set of types or a logical combination of types. An instance matches the single type designated by the tag or the specified combination of types. |
 
 **Primitive Types**:
 
+A primitive type specifies a space of possible values without regard to programming language
+constructs or hardware limits. Restrictions such as range, precision, size, patterns and formats
+are specified using the type-specific options defined in [Section 3.2.1](#321-type-options).
+
 **Compound Types**:
 
-JADN Compound types define logical collections and express both semantic characteristics and abstract syntax.
+A compound type specifies a collection of values, defining both collection semantics and the abstract syntax
+of its members.
 
 Collection semantics defines:
 * if order is significant when comparing instances (Ordered)
-* if duplicate values are prohibited when validating instances (Unique)
+* if duplicate values are allowed when validating an instance (Unique)
 
 Collection abstract syntax defines:
 * whether all members have the same type (Type Syntax) or each member's type is specified
-individually (Field Syntax)
-* whether members are unnamed (Array, ArrayOf) or named (Map, MapOf, Record) -- field names 
-must be unique and so can exist only for unique collection types
+individually (Field Syntax).
+* whether members are unnamed (Array, ArrayOf) or named (Map, MapOf, Record). Field names 
+must be unique and so can exist only for unique collection types.
 * whether serialized members are identified by position (Array), name (Map, MapOf),
-or either position or name (Record) -- positional encoding can be used only with
-data formats that preserve order
+or either position or name (Record). Positional encoding can be used only with data constructs
+that preserve order.
 
 Table 3-2 summarizes the relationship between Compound types and collection behavior.
-The notation X+y indicates that the definition of type X includes type option y defined in
+The notation `X+y` indicates that the definition of type `X` includes type option `y` defined in
 [Section 3.2.1](#321-type-options).
 
 ###### Table 3-2. Mapping Logical Collections to Compound Types
@@ -508,10 +513,13 @@ The notation X+y indicates that the definition of type X includes type option y 
 | true    | true   | OrderedSet              | ArrayOf+unique    | Map+seq<br>MapOf+seq<br>Record+seq |
 | false   | false  | Bag                     | ArrayOf+unordered | none                               |
 
-Elements of Sequence and OrderedSet collections are selected by position.
-The elements of a Bag collection cannot be selected; accessing returns an arbitrary member.
+Members of an ArrayOf or Array type are selected by ordinal position.
+Members of a Record type are selected by either position or name depending on data format.
+The members of a Bag collection cannot be selected; accessing a Bag instance returns an arbitrary member.
 
 **Union Types**:
+
+A union type specifies a set of alternatives against which instances are matched. See [Section 3.2.2.2](#3222)
 
 **Conformance**:
 
@@ -641,8 +649,7 @@ Type                Name           Limit   Description
 -----               -----          -----   -----------
 Binary              $MaxBinary     255     Maximum number of octets
 String              $MaxString     255     Maximum number of characters
-Array, ArrayOf,     $MaxElements   100     Maximum number of items/properties
-Map, MapOf, Record
+ArrayOf, MapOf      $MaxElements   100     Maximum number of items/properties
 ```
 ###### Figure 3-2: JADN Default Size Limits
 
@@ -704,24 +711,24 @@ TypeOption = Choice
 
 ###### Table 3-3. Allowed Options
 
-| BaseType | Allowed Options |
-| :--- | :--- |
-| Binary | minv, maxv, format |
-| Boolean | |
-| Integer | minv, maxv, format |
-| Number | minf, maxf, format |
-| String | minv, maxv, format, pattern |
-| Enumerated | id, enum, pointer, extend |
-| Choice | id, extend |
-| Array | extend, format, minv, maxv |
-| ArrayOf | vtype, minv, maxv, unique, set, unordered |
-| Map | id, extend, minv, maxv |
-| MapOf | vtype, ktype, minv, maxv |
-| Record | extend, minv, maxv |
+| BaseType   | Allowed Options                           |
+|:-----------|:------------------------------------------|
+| Binary     | minv, maxv, format                        |
+| Boolean    |                                           |
+| Integer    | minv, maxv, format                        |
+| Number     | minf, maxf, format                        |
+| String     | minv, maxv, format, pattern               |
+| Array      | minv, maxv, format, extend                |
+| ArrayOf    | vtype, minv, maxv, unique, set, unordered |
+| Map        | id, minv, maxv, seq, extend               |
+| MapOf      | vtype, ktype, minv, maxv, seq             |
+| Record     | minv, maxv, seq, extend                   |
+| Enumerated | id, enum, pointer, extend                 |
+| Choice     | id, combine, extend                       |
 
 #### 3.2.1.1 Field Identifiers
 
-The *id* option used with Enumerated, Choice, and Map types determines how fields are specified in API instances of these types.
+The *id* option used with Map, Enumerated, and Choice types determines how fields are specified in API instances of these types.
 If the *id* option is absent, API instances use the FieldName string and the type is referred to as "named".
 If the *id* option is present, API instances use the FieldID tag and the type is referred to as "labeled".
 The Record type is always named and has no *id* option; the Array type is its labeled equivalent.
@@ -816,7 +823,7 @@ The *combine* option specifies that a [Choice](#3222-tagged-and-untagged-unions)
 against a logical combination of types. The single-character value indicates the combination type:
 * A = AND: data must be an instance of `allOf` the Choice types
 * O = OR: data must be an instance of `anyOf` the Choice types (at least one, short-circuit evaluated in field order)
-* X = XOR: data must be an instance of exactly `oneOf` the Choice types and no others
+* X = XOR: data must be an instance of exactly `oneOf` the Choice types
 
 #### 3.2.1.13 Extension Point
 The *extend* option is an assertion that an Enumerated, Choice, Array, Map or Record type MAY be incomplete and that
@@ -877,18 +884,18 @@ The Choice type selects one type or a logical combination of types from a set. B
 a discriminated ([tagged](#taggedunion)) union where data instances contain a tag (FieldName or FieldId)
 indicating which FieldType from the Choice to evaluate.
 
-If the Choice has a logical combination option, data instances must match`anyOf` (OR), `allOf` (AND),
-or exactly `oneOf` (XOR) the FieldTypes in the Choice.
-This option is an untagged [union](#union): data instances do not contain a tag indicating which types
+If a Choice type has a [combine](#32112-combine) type option, data instances match a logical combination
+of types (`anyOf` (OR), `allOf` (AND), or exactly `oneOf` (XOR)) the field types in the Choice.
+The combine option specifies an untagged [union](#union): data instances do not contain a tag indicating which types
 apply; instead the Choice's FieldTypes are evaluated to determine which, if any, validate the data.
 The `anyOf` option performs short-circuit evaluation; the first FieldType to match, in field order, indicates the
 instance type. The `allOf` and `oneOf` options always perform the evaluation against all FieldTypes.
 
 ##### 3.2.2.2.1 Tagged Union
-The Choice type represents a [Discriminated Union](#union), a data structure that could take on several different, but fixed, types.
-By default a Choice is a Map with exactly one key-value pair, where the key determines the value type.
-But if the *tagid* option is present on a Choice field in an Array or Record container,
-it indicates that a separate Tag field within that container determines the value type.
+The Choice type without a combine option represents a [discriminated union](#union), a Map with exactly
+one tag:type pair where the tag indicates the value type. By default the tag is included in the instance
+value. But if the *tagid* option is present on a Choice field in an Array or Record container,
+a separate field within that container contains the tag separagely from the instance value.
 
 * The Tag field MUST be an Enumerated type derived from the Choice.  It MAY contain a subset of fields from the Choice.
 

--- a/jadn-v1.1.md
+++ b/jadn-v1.1.md
@@ -5,7 +5,7 @@
 
 ## Working Draft 1 (Version 1.0 Committee Specification 01)
 
-## 12 June 2024
+## 26 June 2024
 
 &nbsp;
 
@@ -99,7 +99,7 @@ For complete copyright information please see the Notices section in the Appendi
 
 # Table of Contents
 - [1 Introduction](#1-introduction)
-  - [1.1 Changes from earlier versions](#11-changes-from-earlier-versions)
+  - [1.1 Changes from earlier versions](#11-changes-from-csd-01)
   - [1.2 Glossary](#12-glossary)
     - [1.2.1 Definitions of terms](#121-definitions-of-terms)
     - [1.2.2 Acronyms and abbreviations](#122-acronyms-and-abbreviations)
@@ -246,8 +246,7 @@ for each base type that produce physical data in the desired format.
     An instance, or API value, is an item of information that satisfies the structure and value constraints
     defined by a type.  Types are defined by an information modeling language; JADN built-in types are:
     * **Primitive:** Boolean, Binary, Integer, Number, String
-    * **Enumeration:** Enumerated
-    * **Specialization:** Choice
+    * **Union:** Enumerated, Choice
     * **Compound:** Array, ArrayOf, Map, MapOf, Record
 
 * **Instance Equality**:
@@ -455,24 +454,23 @@ JADN's base types are:
 
 ###### Table 3-1. JADN Base Types
 
-|      Type          |       Definition                                                |
-| :----------------- | :-------------------------------------------------------------- |
-|  **Primitive**     |                                                                 |
-| Binary             | A sequence of octets.  Length is the number of octets.          |
-| Boolean            | An element with one of two values: true or false.               |
-| Integer            | A positive or negative whole number.                            |
-| Number             | A real number.                                                  |
-| String             | A sequence of characters, each of which has a Unicode codepoint.  Length is the number of characters. |
-| **Enumeration**    |                                                                 |
-| Enumerated         | A vocabulary of items where each item has an id and a string value |
-| **Specialization** |                                                                 |
-| Choice             | A [discriminated union](#union): one type selected from a set of named or labeled types. |
-| **Compound**     |                                                               |
-| Array              | An ordered list of labeled fields with positionally-defined semantics. Each field has a position, label, and type. |
-| ArrayOf(*vtype*)   | A collection of fields with the same semantics. Each field has type *vtype*. Ordering and uniqueness are specified by a collection option. |
-| Map                | An unordered map from a set of specified keys to values with semantics bound to each key. Each key has an id and name or label, and is mapped to a value type. |
-| MapOf(*ktype*, *vtype*) | An unordered map from a set of keys of the same type to values with the same semantics. Each key has key type *ktype*, and is mapped to value type *vtype*. |
-| Record             | An ordered map from a list of keys with positions to values with positionally-defined semantics. Each key has a position and name, and is mapped to a value type. Represents a row in a spreadsheet or database table. |
+| Type                    | Definition                                                                                                                                                                                                             |
+|:------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Primitive**           |                                                                                                                                                                                                                        |
+| Binary                  | A sequence of octets.  Length is the number of octets.                                                                                                                                                                 |
+| Boolean                 | An element with one of two values: true or false.                                                                                                                                                                      |
+| Integer                 | A positive or negative whole number.                                                                                                                                                                                   |
+| Number                  | A real number.                                                                                                                                                                                                         |
+| String                  | A sequence of characters, each of which has a Unicode codepoint.  Length is the number of characters.                                                                                                                  |
+| **Union**               |                                                                                                                                                                                                                        |
+| Enumerated              | A vocabulary: one item (id/string pair) selected from a set of items.                                                                                                                                                  |
+| Choice                  | A tagged (discriminated) or untagged union: a type or logical combination of types.                                                                                                                                    |
+| **Compound**            |                                                                                                                                                                                                                        |
+| Array                   | An ordered list of labeled fields with positionally-defined semantics. Each field has a position, label, and type.                                                                                                     |
+| ArrayOf(*vtype*)        | A collection of fields with the same semantics. Each field has type *vtype*. Ordering and uniqueness are specified by a collection option.                                                                             |
+| Map                     | An unordered map from a set of specified keys to values with semantics bound to each key. Each key has an id and name or label, and is mapped to a value type.                                                         |
+| MapOf(*ktype*, *vtype*) | An unordered map from a set of keys of the same type to values with the same semantics. Each key has key type *ktype*, and is mapped to value type *vtype*.                                                            |
+| Record                  | An ordered map from a list of keys with positions to values with positionally-defined semantics. Each key has a position and name, and is mapped to a value type. Represents a row in a spreadsheet or database table. |
 
 * An application that uses JADN types MUST exhibit the behavior specified in Table 3-1.
 Applications MAY use any programming language data types or mechanisms that exhibit the required behavior.
@@ -483,22 +481,36 @@ otherwise identical instance without that key.
 * The length of an Array, ArrayOf or Record instance MUST not include null values after the last non-null value.
 * Two Array, ArrayOf or Record instances that differ only in the number of trailing nulls MUST compare as equal.
 
-As described in Table 3-1, JADN compound types define if their members are *Ordered* and/or *Unique*.
-They also distinguish between homogeneous collections where all members have the same type
-and heterogeneous collections where each member has a specified type.
-For homogeneous collections JADN uses the single "ArrayOf" type with a *set*, *unique* or *unordered*
-option ([Section 3.2.1](#321-type-options)) rather than defining separate names for each collection type.
+JADN Compound types define logical collections and express both semantic characteristics and abstract syntax.
 
-| Ordered | Unique | Traditional<br>Name | JADN<br>Same Type | JADN<br>Specified Type |
-| ------- | ------ | ---------- | ------------------ | -------- |
-| false   | true   | Set        | ArrayOf+set, MapOf | Map      |
-| true    | false  | Sequence   | ArrayOf            | Array    |
-| true    | true   | OrderedSet | ArrayOf+unique     | Record   |
-| false   | false  | Bag        | ArrayOf+unordered  | none     |
+Collection semantics defines:
+* if order is significant when comparing instances (Ordered)
+* if duplicate values are prohibited when validating instances (Unique)
 
-Accessing an element of a collection whose values are neither ordered nor unique
-returns an arbitrarily-chosen element. Elements of other collections are
-deterministically accessed by position, value, or for the Record type either position or value.
+Collection abstract syntax defines:
+* whether all members have the same type (Type Syntax) or each member's type is specified
+individually (Field Syntax)
+* whether members are unnamed (Array, ArrayOf) or named (Map, MapOf, Record) -- field names 
+must be unique and so can exist only for unique collection types
+* whether serialized members are identified by position (Array), name (Map, MapOf),
+or either position or name (Record) -- positional encoding can be used only with
+data formats that preserve order
+
+Table 3-2 summarizes the relationship between Compound types and collection behavior.
+The notation X+y indicates that the definition of type X includes type option y defined in
+[Section 3.2.1](#321-type-options).
+
+###### Table 3-2. Mapping Logical Collections to Compound Types
+
+| Ordered | Unique | Collection<br>Semantics | Type<br>Syntax    | Field<br>Syntax                    |
+|---------|--------|-------------------------|-------------------|------------------------------------|
+| false   | true   | Set                     | ArrayOf+set       | Map<br>MapOf<br>Record             |
+| true    | false  | Sequence                | ArrayOf           | Array                              |
+| true    | true   | OrderedSet              | ArrayOf+unique    | Map+seq<br>MapOf+seq<br>Record+seq |
+| false   | false  | Bag                     | ArrayOf+unordered | none                               |
+
+Elements of Sequence and OrderedSet collections are selected by position.
+The elements of a Bag collection cannot be selected; accessing returns an arbitrary member.
 
 ## 3.1 Type Definitions
 JADN type definitions have a fixed structure designed to be easily describable, easily processed, stable, and extensible.
@@ -666,8 +678,10 @@ TypeOption = Choice
   113 unique    Boolean    // 'q' ArrayOf instance must not contain duplicate values (Section 3.2.1.8)
   115 set       Boolean    // 's' ArrayOf instance is unordered and unique (Section 3.2.1.9)
    98 unordered Boolean    // 'b' ArrayOf instance is unordered (Section 3.2.1.10)
-   88 extend    Boolean    // 'X' Type is extensible; new Items or Fields may be appended (Section 3.2.1.11)
-   33 default   String     // '!' Default value (Section 3.2.1.12)
+  111 seq       Boolean    // 'o' Map, MapOf, or Record instance is ordered and unique (Section 3.2.1.11)
+   67 combine   String     // 'C' Choice is an untagged union, a logical combination of types: (Section 3.2.1.12) 
+   88 extend    Boolean    // 'X' Type is extensible; new Items or Fields may be appended (Section 3.2.1.13)
+   33 default   String     // '!' Default value (Section 3.2.1.14)
 ```
 
 * TypeOptions MUST contain zero or one instance of each TypeOption.
@@ -781,14 +795,24 @@ The *unordered* option specifies that an ArrayOf type may contain duplicate valu
 defined order.  Because values cannot be selected by value or position, it has the semantics of a "bag" or "urn"
 from which elements are picked at random.
 
-#### 3.2.1.11 Extension Point
+#### 3.2.1.11 Seq
+The *seq* option specifies that a Map, MapOf or Record instance is an OrderedSet.
+
+#### 3.2.1.12 Combine
+The *combine* option specifies that a [Choice](#3222-tagged-and-untagged-unions) instance must be valid
+against a logical combination of types. The single-character value indicates the combination type:
+* A = AND: data must be an instance of `allOf` the Choice types
+* O = OR: data must be an instance of `anyOf` the Choice types (at least one, short-circuit evaluated in field order)
+* X = XOR: data must be an instance of exactly `oneOf` the Choice types and no others
+
+#### 3.2.1.13 Extension Point
 The *extend* option is an assertion that an Enumerated, Choice, Array, Map or Record type MAY be incomplete and that
 future versions MAY add new fields that do not change the definitions of existing fields.  This option does not affect
 the validity of data with respect to a specific schema, it is an indicator that applications may be able to obtain
 a newer version of the same package for which the data is valid. Types without this option assert that
 the package identifier will be changed if any field is added, modified, or deleted.
 
-#### 3.2.1.12 Default Value
+#### 3.2.1.14 Default Value
 The *default* option specifies the initial or default value of a field. Applications deserializing
 a document MUST initialize an unspecified type with its default value.
 Serialization behavior is not defined; applications MAY omit or populate fields whose values equal the default.
@@ -835,7 +859,19 @@ as described in [Section 3.3.2](#332-field-multiplicity).
 Within a Choice type *minc* values of 0 and 1 are equivalent because all fields are optional and exactly
 one must be present. Values greater than 1 specify an array of elements.
 
-#### 3.2.2.2 Discriminated Union with Explicit Tag
+#### 3.2.2.2 Tagged and Untagged Unions
+The Choice type selects one type or a logical combination of types from a set. By default Choice is
+a discriminated ([tagged](#taggedunion)) union where data instances contain a tag (FieldName or FieldId)
+indicating which FieldType from the Choice to evaluate.
+
+If the Choice has a logical combination option, data instances must match`anyOf` (OR), `allOf` (AND),
+or exactly `oneOf` (XOR) the FieldTypes in the Choice.
+This option is an untagged [union](#union): data instances do not contain a tag indicating which types
+apply; instead the Choice's FieldTypes are evaluated to determine which, if any, validate the data.
+The `anyOf` option performs short-circuit evaluation; the first FieldType to match, in field order, indicates the
+instance type. The `allOf` and `oneOf` options always perform the evaluation against all FieldTypes.
+
+##### 3.2.2.2.1 Tagged Union
 The Choice type represents a [Discriminated Union](#union), a data structure that could take on several different, but fixed, types.
 By default a Choice is a Map with exactly one key-value pair, where the key determines the value type.
 But if the *tagid* option is present on a Choice field in an Array or Record container,
@@ -1698,6 +1734,8 @@ Boyer, J., et. al., *"Experiences with JSON and XML Transformations"*, October 2
 ###### [UML]
 *"Unified Modeling Language"*, Version 2.5.1, December 2017, https://www.omg.org/spec/UML/2.5.1/PDF
 ###### [UNION]
+"Union Type", Wikipedia, https://en.wikipedia.org/wiki/Union_type
+###### [TAGGEDUNION]
 "Tagged Union", Wikipedia, https://en.wikipedia.org/wiki/Tagged_union.
 
 -------


### PR DESCRIPTION
Changes:
* 102: fix broken link
* 249, Table 3-1: list Enumerated and Choice under a single Union category (categories are now Primitive, Union, Compound)
* 484-513: discuss correspondence between 4 logical (semantic) collection types and 5 JADN compound types
* 681, Section 3.2.1.11-12: add ordered set (seq) and untagged union (combine) type options
* Section 3.2.2.2: discuss new untagged union option for Choice type
* 1737: add informative reference for untagged union

Note: GitHub won't display rich diff; it may be easier to read full document https://github.com/davaya/openc2-jadn/blob/basetypes/jadn-v1.1.md